### PR TITLE
Update dependencies for React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
   },
   "homepage": "https://github.com/Artear/ReactResumableJS#readme",
   "dependencies": {
-    "prop-types": "^15.5.0",
-    "react": "^15.0.0",
-    "react-dom": "^15.3.0",
-    "resumablejs": "^1.0.2"
+    "prop-types": "^15.6.0",
+    "react": "^16.1.1",
+    "react-dom": "^16.1.1",
+    "resumablejs": "^1.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.0.20",


### PR DESCRIPTION
When using this in a project that uses React 16, I was getting this error when an upload completed:
```
ReactBaseClasses.js?79b60dc:66 
Uncaught TypeError: this.updater.enqueueCallback is not a function
    at ReactResumableJs.module.exports.ReactComponent.setState (ReactBaseClasses.js?79b60dc:66)
    at Resumable.<anonymous> (react-resumable-js.js?f642261:106)
    at Resumable.$.fire (resumable.js?f642261:134)
    at ResumableChunk.chunkEvent [as callback] (resumable.js?f642261:461)
    at XMLHttpRequest.doneHandler (resumable.js?f642261:712)
```
Updating ReactResumableJS to use React 16 solves this.